### PR TITLE
Add Phoenix LiveView skeleton

### DIFF
--- a/web/.formatter.exs
+++ b/web/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+web-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,20 @@
+# Web Interface for StockNotes
+
+This Phoenix LiveView application replicates the original Python features using the existing `short_term` and `long_term` folders for storage.
+
+## Setup
+
+1. Install Elixir and Erlang.
+2. Fetch dependencies:
+
+   ```bash
+   mix deps.get
+   ```
+
+3. Start the server with:
+
+   ```bash
+   mix phx.server
+   ```
+
+The application expects the `short_term` and `long_term` directories to be in the project root (one level above this `web` folder). Notes are appended to the same text files used by the Python version.

--- a/web/config/config.exs
+++ b/web/config/config.exs
@@ -1,0 +1,15 @@
+import Config
+
+config :web, WebWeb.Endpoint,
+  url: [host: "localhost"],
+  render_errors: [view: WebWeb.ErrorView, accepts: ~w(html json), layout: false],
+  pubsub_server: Web.PubSub,
+  live_view: [signing_salt: "changeme"]
+
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+config :phoenix, :json_library, Jason
+
+import_config "#{config_env()}.exs"

--- a/web/config/dev.exs
+++ b/web/config/dev.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :web, WebWeb.Endpoint,
+  http: [port: 4000],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: String.duplicate("abcdefgh", 8),
+  watchers: []
+
+config :web, dev_routes: true

--- a/web/config/prod.exs
+++ b/web/config/prod.exs
@@ -1,0 +1,6 @@
+import Config
+
+config :web, WebWeb.Endpoint,
+  url: [host: System.get_env("PHX_HOST") || "example.com", port: 80],
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  secret_key_base: System.get_env("SECRET_KEY_BASE") || "prodsecret"

--- a/web/config/runtime.exs
+++ b/web/config/runtime.exs
@@ -1,0 +1,9 @@
+import Config
+
+if config_env() == :prod do
+  config :web, WebWeb.Endpoint,
+    http: [
+      ip: {0, 0, 0, 0},
+      port: String.to_integer(System.get_env("PORT") || "4000")
+    ]
+end

--- a/web/config/test.exs
+++ b/web/config/test.exs
@@ -1,0 +1,1 @@
+import Config

--- a/web/lib/web.ex
+++ b/web/lib/web.ex
@@ -1,0 +1,18 @@
+defmodule Web do
+  @moduledoc """
+  Documentation for `Web`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> Web.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/web/lib/web/application.ex
+++ b/web/lib/web/application.ex
@@ -1,0 +1,25 @@
+defmodule Web.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      WebWeb.Endpoint
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Web.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  @impl true
+  def config_change(changed, _new, removed) do
+    WebWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/web/lib/web_web.ex
+++ b/web/lib/web_web.ex
@@ -1,0 +1,47 @@
+defmodule WebWeb do
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: WebWeb
+      import Plug.Conn
+      alias WebWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def live_view do
+    quote do
+      use Phoenix.LiveView,
+        layout: {WebWeb.LayoutView, :root}
+    end
+  end
+
+  def live_component do
+    quote do
+      use Phoenix.LiveComponent
+    end
+  end
+
+  def html do
+    quote do
+      use Phoenix.Component
+      import Phoenix.HTML
+      alias WebWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+      import Phoenix.LiveView.Router
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/web/lib/web_web/endpoint.ex
+++ b/web/lib/web_web/endpoint.ex
@@ -1,0 +1,31 @@
+defmodule WebWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :web
+
+  socket "/live", Phoenix.LiveView.Socket
+
+  plug Plug.Static,
+    at: "/",
+    from: :web,
+    gzip: false,
+    only: ~w(assets images favicon.ico robots.txt)
+
+  if Application.compile_env(:web, :dev_routes) do
+    plug Phoenix.LiveDashboard.RequestLogger,
+      param_key: "request_logger",
+      cookie_key: "request_logger"
+  end
+
+  plug Plug.RequestId
+  plug Plug.Telemetry, event_prefix: [:web, :endpoint]
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+  plug Plug.Session, store: :cookie, key: "_web_key", signing_salt: "change"
+
+  plug WebWeb.Router
+end

--- a/web/lib/web_web/live/notes_live.ex
+++ b/web/lib/web_web/live/notes_live.ex
@@ -1,0 +1,88 @@
+defmodule WebWeb.NotesLive do
+  use WebWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, date: Date.utc_today(), mode: :short, note: "", stock: "")}
+  end
+
+  @impl true
+  def handle_event("set_date", %{"date" => date}, socket) do
+    {:noreply, assign(socket, :date, date)}
+  end
+
+  def handle_event("set_mode", %{"mode" => mode}, socket) do
+    {:noreply, assign(socket, :mode, String.to_atom(mode))}
+  end
+
+  def handle_event("add_stock", %{"stock" => stock}, socket) do
+    stock = String.upcase(stock)
+    File.mkdir_p!("short_term")
+    File.mkdir_p!("long_term")
+    for dir <- ["short_term", "long_term"] do
+      path = Path.join(dir, stock <> ".txt")
+      unless File.exists?(path) do
+        File.write!(path, "Notes for #{stock}\n\n")
+      end
+    end
+    {:noreply, socket}
+  end
+
+  def handle_event("add_note", %{"stock" => stock, "note" => note}, socket) do
+    stock = String.upcase(stock)
+    dir = if socket.assigns.mode == :short, do: "short_term", else: "long_term"
+    path = Path.join(dir, stock <> ".txt")
+    File.write!(path, "#{socket.assigns.date}: #{note}\n", [:append])
+    {:noreply, socket}
+  end
+
+  def handle_event("read_notes", %{"stock" => stock}, socket) do
+    stock = String.upcase(stock)
+    short = Path.join("short_term", stock <> ".txt")
+    long = Path.join("long_term", stock <> ".txt")
+    notes =
+      [short, long]
+      |> Enum.map(fn path ->
+        if File.exists?(path), do: File.read!(path), else: ""
+      end)
+      |> Enum.join("\n----\n")
+    {:noreply, assign(socket, :notes, notes)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <h2>Stock Notes</h2>
+    <form phx-submit="set_date">
+      <input type="date" name="date" value={@date} />
+      <button type="submit">Set Default Date</button>
+    </form>
+
+    <form phx-submit="set_mode">
+      <select name="mode">
+        <option value="short" selected={@mode == :short}>Short</option>
+        <option value="long" selected={@mode == :long}>Long</option>
+      </select>
+      <button type="submit">Switch Mode</button>
+    </form>
+
+    <form phx-submit="add_stock">
+      <input type="text" name="stock" placeholder="Stock code" />
+      <button type="submit">Add Stock</button>
+    </form>
+
+    <form phx-submit="add_note">
+      <input type="text" name="stock" placeholder="Stock code" />
+      <input type="text" name="note" placeholder="Note" />
+      <button type="submit">Add Note</button>
+    </form>
+
+    <form phx-submit="read_notes">
+      <input type="text" name="stock" placeholder="Stock code" />
+      <button type="submit">Read Notes</button>
+    </form>
+
+    <pre><%= @notes %></pre>
+    """
+  end
+end

--- a/web/lib/web_web/router.ex
+++ b/web/lib/web_web/router.ex
@@ -1,0 +1,17 @@
+defmodule WebWeb.Router do
+  use WebWeb, :router
+
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  scope "/", WebWeb do
+    pipe_through :browser
+
+    live "/", NotesLive
+  end
+end

--- a/web/lib/web_web/views/error_view.ex
+++ b/web/lib/web_web/views/error_view.ex
@@ -1,0 +1,6 @@
+defmodule WebWeb.ErrorView do
+  use WebWeb, :html
+
+  def render("404.html", _assigns), do: "Not Found"
+  def render("500.html", _assigns), do: "Internal Server Error"
+end

--- a/web/lib/web_web/views/layout_view.ex
+++ b/web/lib/web_web/views/layout_view.ex
@@ -1,0 +1,19 @@
+defmodule WebWeb.LayoutView do
+  use WebWeb, :html
+
+  def root(assigns) do
+    ~H"""
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <title>Stock Notes</title>
+        <%= csrf_meta_tag() %>
+      </head>
+      <body>
+        <%= @inner_content %>
+      </body>
+    </html>
+    """
+  end
+end

--- a/web/mix.exs
+++ b/web/mix.exs
@@ -1,0 +1,35 @@
+defmodule Web.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :web,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger, :runtime_tools],
+      mod: {Web.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:phoenix_live_view, "~> 0.20"},
+      {:phoenix_html, "~> 3.3"},
+      {:phoenix_live_reload, "~> 1.3", only: :dev},
+      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_poller, "~> 1.0"},
+      {:jason, "~> 1.2"},
+      {:plug_cowboy, "~> 2.6"}
+    ]
+  end
+end

--- a/web/test/test_helper.exs
+++ b/web/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/web/test/web_test.exs
+++ b/web/test/web_test.exs
@@ -1,0 +1,8 @@
+defmodule WebTest do
+  use ExUnit.Case
+  doctest Web
+
+  test "greets the world" do
+    assert Web.hello() == :world
+  end
+end


### PR DESCRIPTION
## Summary
- add basic Phoenix LiveView project in `web`
- implement `NotesLive` for adding stock codes and notes
- integrate storage with existing `short_term` and `long_term` folders
- provide setup instructions in `web/README.md`

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ff8011628832897120d7d145bdeca